### PR TITLE
Fix link to idea list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All the projects listed [here][NumFOCUS-Projects].
 [Cython]: http://cython.org/
 [DataCarpentry]: http://datacarpentry.org/
 [GSoC]: https://www.google-melange.com/gsoc/homepage/google/gsoc2015
-[IL]: ideas-list.md
+[IL]: 2015/ideas-list.md
 [IPython]: http://ipython.org/
 [Julia]: http://julialang.org/
 [Matplotlib]: http://matplotlib.sourceforge.net/


### PR DESCRIPTION
The link for 'idea list' needs to be updated to find the file which is under the 2015 directory.