### PR TITLE
CONTRIBUTING-students.md: Add 'GSoC' reference for linking

### DIFF
--- a/CONTRIBUTING-students.md
+++ b/CONTRIBUTING-students.md
@@ -75,3 +75,4 @@ Your final proposal must be submitted to [GSoC][]
 
 [IL]: 2015/ideas-list.md
 [issues]: https://github.com/numfocus/gsoc/issues
+[GSoC]: https://www.google-melange.com/gsoc/homepage/google/gsoc2015


### PR DESCRIPTION
Fix the reference broken by 0af2f488 (Split CONTRIBUTING.md,
2015-03-09).