### PR TITLE
Add PR template for students

### DIFF
--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,6 @@
+Checklist for prospect students for Google Summer of Code 2016:
+
+- [ ] I contacted NumFOCUS mentors before writing my proposal
+- [ ] I showed you my contribution (it can be any form: PoC project idea, some sample code or just a link to your commits from other project)
+- [ ] I linked to my sample contribution from the proposal
+- [ ] I linked to my opened issues in numfocus/gsoc repository from the proposal

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,6 +1,6 @@
 Checklist for prospect students for Google Summer of Code 2016:
 
 - [ ] I contacted NumFOCUS mentors before writing my proposal
-- [ ] I showed you my contribution (it can be any form: PoC project idea, some sample code or just a link to your commits from other project)
+- [ ] I showed you my contribution (it can be any form: proof-of-concept project idea, some sample code or just a link to your commits from other project)
 - [ ] I linked to my sample contribution from the proposal
 - [ ] I linked to my opened issues in numfocus/gsoc repository from the proposal


### PR DESCRIPTION
When students open PRs to submit drafts of their proposals, the PR messages should contain this small check list of things that should be done before / put into the proposal.

More: https://github.com/blog/2111-issue-and-pull-request-templates