### PR TITLE
Include nteract status and ideas page

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ a sub-org must:
 | [IPython]                       | Unkown                           |                                                     |
 | [Julia]                         | Unkown                           |                                                     |
 | [Matplotlib]                    | Unkown                           |                                                     |
-| [nteract]                       | Unkown                           |                                                     |
+| [nteract]                       | Applying under NumFOCUS umbrella | https://github.com/nteract/nteract/wiki/GSoC-2017-Ideas |
 | [NumPy]                         | Unkown                           |                                                     |
 | [Project Jupyter](Jupyter)      | Unkown                           |                                                     |
 | [pandas]                        | Unkown                           |                                                     |


### PR DESCRIPTION
We've just started putting together ideas on our wiki and are looking to flesh out the project descriptions.