### PR TITLE
GSoC link correction in Contributing-student.md

### DIFF
--- a/CONTRIBUTING-students.md
+++ b/CONTRIBUTING-students.md
@@ -174,7 +174,7 @@ help a lot.
 
 ### Final Proposal
 
-Your final proposal must be submitted to [GSoC](summerofcode.withgoogle.com) as
+Your final proposal must be submitted to [GSoC](http://summerofcode.withgoogle.com) as
 a PDF file. Your proposal name should start with *[sub-org-name]* to make
 identification easier for the mentors. To convert a draft that you have written
 before into PDF you can use [Pandoc][Pandoc].

--- a/CONTRIBUTING-students.md
+++ b/CONTRIBUTING-students.md
@@ -174,7 +174,7 @@ help a lot.
 
 ### Final Proposal
 
-Your final proposal must be submitted to [GSoC](https://summerofcode.withgoogle.com) as
+Your final proposal must be submitted to [GSoC](summerofcode.withgoogle.com) as
 a PDF file. Your proposal name should start with *[sub-org-name]* to make
 identification easier for the mentors. To convert a draft that you have written
 before into PDF you can use [Pandoc][Pandoc].

--- a/CONTRIBUTING-students.md
+++ b/CONTRIBUTING-students.md
@@ -174,7 +174,7 @@ help a lot.
 
 ### Final Proposal
 
-Your final proposal must be submitted to [GSoC](summerofcode.withgoogle.com) as
+Your final proposal must be submitted to [GSoC](https://summerofcode.withgoogle.com) as
 a PDF file. Your proposal name should start with *[sub-org-name]* to make
 identification easier for the mentors. To convert a draft that you have written
 before into PDF you can use [Pandoc][Pandoc].


### PR DESCRIPTION
Hi

The GSoC link in file contributing-student.md was not working correctly and gives "403" error. The problem was that its missing " http:// " before link. So I added it due to which it has now started to work correctly.
In any case to clear and explain my pull request, feel free to mail me.

Thanks!

Regards, 
Zuhaib Asad
mail: zuhaibasad@gmail.com