### PR TITLE
PR: Update very outdated Spyder link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In alphabetic order.
         no analytical (exact) solution numerically.
       </p>
       <p>
-        <a href="https://fenicsproject.org/">Website</a> | <a href="https://fenicsproject.org/community/">Community Page With Access to Slack</a> | <a href ="https://github.com/numfocus/gsoc/blob/master/2018/ideas-list-fenics.md"> Ideas Page 
+        <a href="https://fenicsproject.org/">Website</a> | <a href="https://fenicsproject.org/community/">Community Page With Access to Slack</a> | <a href ="https://github.com/numfocus/gsoc/blob/master/2018/ideas-list-fenics.md"> Ideas Page
       </p>
    </td>
  </tr>

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ information how to work with them.
 [scikit-learn]: http://scikit-learn.org/stable/
 [SciPy]: http://www.scipy.org/
 [Spack]: https://spack.io
-[Spyder]: http://code.google.com/p/spyderlib/
+[Spyder]: https://www.spyder-ide.org/
 [Statmodels]: http://statsmodels.sourceforge.net/
 [Stan]: http://mc-stan.org/
 [Shogun]: http://www.shogun-toolbox.org


### PR DESCRIPTION
I noticed that the Spyder link in the Readme was to an ancient version of our site on Google code that we haven't used or updated for many years, and so updated it to the modern one. Also cleaned up a bit of trailing whitespace.

Part of the broader spyder-ide/spyder-docs#39 effort