### PR TITLE
Change "he" to "they" in contributing when referring to an individual of indeterminate gender

### DIFF
--- a/CONTRIBUTING-mentors.md
+++ b/CONTRIBUTING-mentors.md
@@ -39,7 +39,7 @@ The **sub-org admins** are responsible for the following:
 
 ## Mentors
 
-To be a mentor please tell your sub-org administrator so he can give you all the
+To be a mentor please tell your sub-org administrator so they can give you all the
 information you need to sign up.
 
 ## Projects
@@ -56,7 +56,7 @@ and have to acquire a huge amount of domain knowledge.
 
 There has to be at least one primary mentor and one backup mentor per project.
 This means you should have at least 2 mentors available. A mentor can only be
-'primary' for one student but a backup for as many as he likes. The sub org
+'primary' for one student but a backup for as many as they like. The sub org
 admin can also be a mentor.
 
 If you have a proposal you can use our [proposal templates][template] and


### PR DESCRIPTION
I noticed this reading over the Contributing-Mentors doc. Particularly for an organization where promoting diversity and inclusion is a big part of its core mission, it probably isn't the best form to directly imply that both sub-org administrators and mentors can only be male. Furthermore, it's not correct modern English, since "he" has disappeared from usage in this context in mainstream forms of the language over the past few decades, and the statement doesn't make grammatical or common sense as is (unless it is established that administrators and mentors must be exclusively male, which I take it is not the case).