### PR TITLE
add about gsoc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 for [Google Summer of Code 2019][GSoC]. [NumFOCUS][] supports and
 promotes world-class, innovative, open source scientific software.
 
+[Google Summer of Code][GSoC] is an annual open source internship program
+sponsored by Google. This repository contains information specific to NumFOCUS'
+participation in GSoC. For general information about the competition, including
+this year's application timeline and key phases involved, please see the [GSoC
+website](https://summerofcode.withgoogle.com/how-it-works/)
+
 <!--
 This Git repository stores information about NumFOCUS' participation in
 Google Summer of Code 2019 program and previous editions.
@@ -20,11 +26,11 @@ application for Google Summer of Code in the current and previous years.
 - [Students](#students)
 - [Sub Organizations](#sub-organizations)
 - [Organizations Confirmed Under NumFOCUS Umbrella](#organizations-confirmed-under-numfocus-umbrella)
-- [About GSoC](#about-gsoc)
 - [NumFOCUS Projects](#numfocus-projects)
     - [Fiscally Sponsored Projects GSoC Status](#fiscally-sponsored-projects-gsoc-status)
     - [Affiliated Projects GSoC Status](#affiliated-projects-gsoc-status)
     - [Other Projects GSoC Status](#other-projects-gsoc-status)
+- [About GSoC](#about-gsoc)
 
 <!-- markdown-toc end -->
 
@@ -373,12 +379,6 @@ In alphabetic order.
  -->
 </table>
 
-## About GSoC
-
-[Google Summer of Code][GSoC] is an annual Open Source internship program
-sponsored by Google. On this site we only collect information specific to
-NumFOCUS. You can find out more about GSoC in general on the official
-[website](https://summerofcode.withgoogle.com/how-it-works/).
 
 ## NumFOCUS Organizations
 
@@ -447,7 +447,6 @@ information how to work with them.
 | [Theano]             | Unknown                          |             |
 | [xarray]             | Unknown                          |             |
 | [Yellowbrick]        | Applying under NumFOCUS umbrella |    https://github.com/wagner2010/gsoc/blob/wagner2010-patch-1/templates/ideas-page-prema.md         |
-
 
 [ArviZ]: https://arviz-devs.github.io/arviz/
 [AstroPy]: http://www.astropy.org/

--- a/README.md
+++ b/README.md
@@ -17,15 +17,14 @@ application for Google Summer of Code in the current and previous years.
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**
 
-- [Google Summer of Code](#google-summer-of-code)
-
-    - [Students](#students)
-    - [Sub Organizations](#sub-organizations)
-    - [Organizations Confirmed Under NumFOCUS Umbrella](#organizations-confirmed-under-numfocus-umbrella)
-    - [NumFOCUS Projects](#numfocus-projects)
-        - [Fiscally Sponsored Projects GSoC Status](#fiscally-sponsored-projects-gsoc-status)
-        - [Affiliated Projects GSoC Status](#affiliated-projects-gsoc-status)
-        - [Other Projects GSoC Status](#other-projects-gsoc-status)
+- [Students](#students)
+- [Sub Organizations](#sub-organizations)
+- [Organizations Confirmed Under NumFOCUS Umbrella](#organizations-confirmed-under-numfocus-umbrella)
+- [About GSoC](#about-gsoc)
+- [NumFOCUS Projects](#numfocus-projects)
+    - [Fiscally Sponsored Projects GSoC Status](#fiscally-sponsored-projects-gsoc-status)
+    - [Affiliated Projects GSoC Status](#affiliated-projects-gsoc-status)
+    - [Other Projects GSoC Status](#other-projects-gsoc-status)
 
 <!-- markdown-toc end -->
 
@@ -373,6 +372,13 @@ In alphabetic order.
  </tr>
  -->
 </table>
+
+## About GSoC
+
+[Google Summer of Code][GSoC] is an annual Open Source internship program
+sponsored by Google. On this site we only collect information specific to
+NumFOCUS. You can find out more about GSoC in general on the official
+[website](https://summerofcode.withgoogle.com/how-it-works/).
 
 ## NumFOCUS Organizations
 


### PR DESCRIPTION
This should make it easier for people to find information about GSoC if they do
not come from the GSoC pages.

fix #303 

@CAM-Gerlach does this change help you find overall information about GSoC? We limited the information on this repository to NumFOCUS specifics on purpose. But we can link more to the official sites.