### PR TITLE
Adding Stan projects to GSoC 2021 application

### DIFF
--- a/2021/ideas-list.md
+++ b/2021/ideas-list.md
@@ -19,6 +19,7 @@ page of each organization under the NumFOCUS umbrella at this page.
   - Numerical Differential Equations  https://sciml.ai/gsoc/gsoc_diffeq/
   - Scientific Machine Learning  https://sciml.ai/gsoc/gsoc_sciml/
   - Symbolic-Numeric Computing  https://sciml.ai/gsoc/gsoc_symbolic/
+- Stan https://github.com/stan-dev/design-docs/blob/master/gsoc_proposals/2021/proposal_main.md
   
 
 See the [README](https://github.com/numfocus/gsoc/blob/master/README.md#organizations-confirmed-under-numfocus-umbrella) for contact information of each org.

--- a/README.md
+++ b/README.md
@@ -410,6 +410,19 @@ In alphabetic order.
        </p>
     </td>
   </tr>
+  <tr>
+    <td>
+      <img width="300px" src="img/stan-logo.png">
+    </td>
+    <td>
+       <h1>Stan </h1>
+       <p> Stan is a state-of-the-art platform for statistical modeling and high-performance statistical computation. Thousands of users rely on Stan for statistical modeling, data analysis, and prediction in the social, biological, and physical sciences, engineering, and business. Users specify log density functions in Stan’s probabilistic programming language and get: 1) full Bayesian statistical inference with MCMC sampling (NUTS, HMC). 2) approximate Bayesian inference with variational inference (ADVI) 3) penalized maximum likelihood estimation with optimization (L-BFGS). Stan’s math library provides differentiable probability functions & linear algebra (C++ autodiff). Additional R packages provide expression-based linear modeling, posterior visualization, and leave-one-out cross-validation.
+ </p>
+       <p>
+         <a href="https://mc-stan.org/">Website</a> | <a href="https://discourse.mc-stan.org/">Discourse</a> | <a href="https://github.com/stan-dev/design-docs/blob/master/gsoc_proposals/2021/proposal_main.md">Ideas Page</a> | <a href="https://github.com/stan-dev"> Source Code</a>
+       </p>
+    </td>
+  </tr>
   <!--
   <tr>
     <td>
@@ -461,7 +474,7 @@ information how to work with them.
 | [Shogun]                        | Unknown |                                                    |
 | [SunPy]                         | Unknown |  |
 | [SymPy]                         | Unknown |  |
-| [Stan]                          | Unknown |                                                     |
+| [Stan]                          | Applying under NumFOCUS umbrella | https://github.com/stan-dev/design-docs/blob/master/gsoc_proposals/2021/proposal_main.md  |
 | [yt]                            | Unknown |                                                     |
 
 ### Affiliated Organizations GSoC Status


### PR DESCRIPTION
Hi. Stan plans to apply for GSoC 2021 under the NumFOCUS umbrella.  I'm submitting a PR with relevant Stan info in the README and 2021/ folder including a URL to our project propsals/ideas page. 