### PR TITLE
Add "Colour" to GSoC 2021.

### DIFF
--- a/2021/ideas-list.md
+++ b/2021/ideas-list.md
@@ -6,7 +6,7 @@ page of each organization under the NumFOCUS umbrella at this page.
 
 - AiiDA https://github.com/aiidateam/aiida-core/wiki/GSoC-2021-Projects
 - ArviZ https://github.com/arviz-devs/arviz/wiki/GSoC-2021-projects
-- Colour
+- Colour https://github.com/colour-science/GSoC/blob/master/2021/GSoC-2021-Project-Ideas.md
 - CB-Geo MPM https://github.com/cb-geo/mpm/issues/704#issue-796189505
 - CuPy https://github.com/cupy/cupy/wiki/GSoC-2021-Project-Ideas
 - Data Retriever https://github.com/weecology/retriever/wiki/GSoC-2021-Project-Ideas

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ In alphabetic order.
           terms.
        </p>
        <p>
-       <a href="https://www.colour-science.org/">Website</a> | <a href="">Ideas List</a> | <a href="colour-developers@colour-science.org">Contact</a> | <a href="https://github.com/colour-science/colour">Source Code</a>
+       <a href="https://www.colour-science.org/">Website</a> | <a href="https://github.com/colour-science/GSoC/blob/master/2021/GSoC-2021-Project-Ideas.md">Ideas List</a> | <a href="mailto:colour-developers@colour-science.org">Contact</a> | <a href="https://github.com/colour-science/colour">Source Code</a>
        </p>
     </td>
   </tr>


### PR DESCRIPTION
Hi,

This PR adds [Colour](https://github.com/colour-science/colour) to GSoC 2021.

Cheers,

Thomas & @MichaelMauderer