### PR TITLE
Fix pandoc code example such that it includes the sub-org-name as requested

### DIFF
--- a/CONTRIBUTING-students.md
+++ b/CONTRIBUTING-students.md
@@ -181,7 +181,7 @@ identification easier for the mentors. To convert a draft that you have written
 before into PDF you can use [Pandoc][Pandoc].
 
 ~~~
-$ pandoc -f markdown -t pdf YYYY/proposals/your-name.md
+$ pandoc -f markdown -t pdf YYYY/proposals/sub-org-name-your-name.md
 ~~~
 
 


### PR DESCRIPTION
Your proposal name should start with *[sub-org-name]* to make identification easier for the mentors. The pandoc string should reflect that.

Since this is a minor improvement on a technical detail i didn't consider getting in touch with numfocus first.