### PR TITLE
[GSoC2022] Add link to ideas page for Gridap.

### DIFF
--- a/2022/ideas-list.md
+++ b/2022/ideas-list.md
@@ -17,7 +17,7 @@ page of each organization under the NumFOCUS umbrella at this page.
 - PyMC
 - PyTorch-Ignite https://github.com/pytorch/ignite/wiki/GSoC-2022-project
 - QuTiP https://github.com/qutip/qutip/wiki/Google-Summer-of-Code-2022
-- SciML
+- SciML https://sciml.ai/dev/#google_summer_of_code
 - signac
 - Taskflow
 - Zarr

--- a/2022/ideas-list.md
+++ b/2022/ideas-list.md
@@ -10,14 +10,14 @@ page of each organization under the NumFOCUS umbrella at this page.
 - CVXPY https://github.com/cvxpy/GSOC2022
 - Econ-ARK
 - FEniCS
-- Gridap
+- Gridap https://github.com/gridap/GSoC/blob/main/2022/ideas-list.md
 - NetworkX
 - Optuna https://github.com/optuna/optuna/wiki/Optuna-GSoC-2022
 - PyBaMM https://github.com/pybamm-team/PyBaMM/wiki/GSoC-2022-Projects
 - PyMC
 - PyTorch-Ignite https://github.com/pytorch/ignite/wiki/GSoC-2022-project
 - QuTiP https://github.com/qutip/qutip/wiki/Google-Summer-of-Code-2022
-- SciML https://sciml.ai/dev/#google_summer_of_code
+- SciML
 - signac
 - Taskflow
 - Zarr


### PR DESCRIPTION
This adds a link to the ideas page for Gridap regarding GSoC 2022.