### PR TITLE
Add pvlib ideas page

### DIFF
--- a/2024/ideas-list.md
+++ b/2024/ideas-list.md
@@ -21,7 +21,7 @@ page of each organization under the NumFOCUS umbrella at this page.
 - [NetworkX]
 - [OpenFHE]
 - [Open Science Labs]
-- [pvlib]
+- [pvlib](https://github.com/pvlib/pvlib-python/wiki/GSoC-2024-Projects)
 - [PyBaMM](https://pybamm.org/gsoc/2024/)
 - [PyLops]
 - [PyMC]

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ In alphabetic order.
        <h1>pvlib</h1>
        <p> pvlib python provides a set of functions and classes for simulating the performance of photovoltaic energy systems. </p>
        <p>
-       <a href="https://pvlib-python.readthedocs.io/en/stable/">Website</a> | <a href="https://groups.google.com/forum/#!forum/pvlib-python">Google Group Forum</a> | <a href="https://github.com/pvlib/pvlib-python/wiki/GSoC-2023-Projects">Ideas Page</a> | <a href="https://github.com/pvlib/pvlib-python"> Source Code</a>
+       <a href="https://pvlib-python.readthedocs.io/en/stable/">Website</a> | <a href="https://groups.google.com/forum/#!forum/pvlib-python">Google Group Forum</a> | <a href="https://github.com/pvlib/pvlib-python/wiki/GSoC-2024-Projects">Ideas Page</a> | <a href="https://github.com/pvlib/pvlib-python"> Source Code</a>
        </p>
     </td>
   </tr>


### PR DESCRIPTION
Adding a link to pvlib's GSoC [ideas page](https://github.com/pvlib/pvlib-python/wiki/GSoC-2024-Projects).

@kandersolar @mikofski 