### PR TITLE
AiiDA: update links for GSoC 2024

### DIFF
--- a/2024/ideas-list.md
+++ b/2024/ideas-list.md
@@ -5,7 +5,7 @@ Since NumFOCUS is an umbrella organization you will only find links to the ideas
 page of each organization under the NumFOCUS umbrella at this page.
 
 - [aeon](https://github.com/aeon-toolkit/aeon-admin/blob/main/gsoc/gsoc-2024-projects.md)
-- [AiiDA]
+- [AiiDA](https://github.com/aiidateam/aiida-core/wiki/GSoC-2024-Projects)
 - [ArviZ]
 - [CB-Geo MPM]
 - [Colour Science]

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ In alphabetic order.
           AiiDA is a python framework for managing computational science workflows, with roots in computational materials science. It helps researchers manage large numbers of simulations (10k, 100k, 1M, ...) and complex workflows involving multiple executables. At the same time, it records the provenance of the entire simulation pipeline with the aim to make it fully reproducible.
        </p>
        <p>
-       <a href="https://www.aiida.net/">Website</a> | <a href="https://github.com/aiidateam/aiida-core/wiki/GSoC-2023-Projects">Ideas List</a> | <a href="https://groups.google.com/g/aiidausers">Google Groups</a> | <a href="https://github.com/aiidateam/aiida-core">Source Code</a>
+       <a href="https://www.aiida.net/">Website</a> | <a href="https://github.com/aiidateam/aiida-core/wiki/GSoC-2024-Projects">Ideas List</a> | <a href="https://aiida.discourse.group/">Discourse</a> | <a href="https://github.com/aiidateam/aiida-core">Source Code</a>
        </p>
     </td>
   </tr>


### PR DESCRIPTION
- link to the community is updated
- links to the 2024 idea list

[readme]: https://github.com/numfocus/gsoc/blob/master/README.md