### PR TITLE
Updated FLOSS Manual link

### DIFF
--- a/CONTRIBUTING-students.md
+++ b/CONTRIBUTING-students.md
@@ -34,7 +34,7 @@ with different backgrounds. At the same time if you have experience using your
 project of choice or one of it's dependencies (e.g., language) make sure to let
 us know about that as
 well.
-The [FLOSS manual](http://write.flossmanuals.net/gsocstudentguide/am-i-good-enough/)
+The [GSoC Guide](https://google.github.io/gsocguides/student/am-i-good-enough#)
 gives a good overview of this part for GSoC.
 
 ## Our Expectations From Students

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | [Sub organizations](#sub-organizations) | [IDEAS LIST][IL] | [Student guides][CONTRIBUTING]  |
 
 [NumFOCUS][] will be applying again as an umbrella mentoring organization
-for [Google Summer of Code 2022][GSoC]. [NumFOCUS][] supports and
+for [Google Summer of Code 2024][GSoC]. [NumFOCUS][] supports and
 promotes world-class, innovative, open source scientific software.
 
 [NumFOCUS][]  is committed to promoting and sustaining a professional and ethical community. Our [Code of Conduct](https://numfocus.org/code-of-conduct) is our effort to uphold these values and it provides a guideline and some of the tools and resources necessary to achieve this.


### PR DESCRIPTION
FLOSS Manual is now called [Google Summer of Code Guide](https://google.github.io/gsocguides/). 
And in Readme.md I updated 2022 to 2024.