### PR TITLE
Add Zarr project list for GSoC 2025

### DIFF
--- a/2025/ideas-list.md
+++ b/2025/ideas-list.md
@@ -8,6 +8,7 @@ page of each organization under the NumFOCUS umbrella at this page.
 - [ArviZ](https://github.com/arviz-devs/arviz/wiki/GsoC-2025-projects)
 - [Data Retriever](https://github.com/weecology/retriever/wiki/GSoC-2025-Project-Ideas)
 - [pvlib](https://github.com/pvlib/pvlib-python/wiki/GSoC-2025-Projects)
+- [Zarr](https://github.com/zarr-developers/gsoc/blob/main/2025/ideas-list.md)
 
 
 See the [README](https://github.com/numfocus/gsoc/blob/master/README.md#organizations-confirmed-under-numfocus-umbrella) for contact information of each org.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ In alphabetic order.
     <td>
        <h1>Bambi</h1>
        <p>
-      Bambi (BAyesian Model Building Interface) is an open source Python package designed to make it easier for practitioners to build statistical models from a wide range of families using a formula notation similar to those found in R. It is built on top of the PyMC probabilistic programming framework and the ArviZ package for exploratory analysis of Bayesian models. 
+      Bambi (BAyesian Model Building Interface) is an open source Python package designed to make it easier for practitioners to build statistical models from a wide range of families using a formula notation similar to those found in R. It is built on top of the PyMC probabilistic programming framework and the ArviZ package for exploratory analysis of Bayesian models.
        </p>
        <p>
          <a href="https://bambinos.github.io/bambi/">Website</a> | <a href="https://github.com/bambinos/bambi/wiki/GSoC-2024-projects">Ideas List</a> | <a href="https://github.com/bambinos/bambi/discussions"> Discussions </a> | <a href="https://github.com/bambinos">Source Code</a>
@@ -538,7 +538,7 @@ In alphabetic order.
        <h1>Zarr</h1>
        <p> Zarr is a file storage format for chunked, compressed, N-dimensional arrays based on an open-source specification. </p>
        <p>
-         <a href="https://zarr.dev/">Website</a> | <a href="https://gitter.im/zarr-developers/community">Gitter</a> | <a href="https://github.com/zarr-developers/gsoc/blob/main/2024/ideas-list.md">Ideas Page</a> | <a href="https://github.com/zarr-developers/zarr-python"> Source Code</a>
+         <a href="https://zarr.dev/">Website</a> | <a href="https://ossci.zulipchat.com/">ZulipChat</a> | <a href="https://github.com/zarr-developers/gsoc/blob/main/2025/ideas-list.md">Ideas Page</a> | <a href="https://github.com/zarr-developers/zarr-python"> Source Code</a>
        </p>
     </td>
   </tr>


### PR DESCRIPTION
xref: https://github.com/zarr-developers/zarr-python/issues/2805

Added projects list for GSoC 2025. Please review @akshaysubr and @decryptofy.
CC: @joshmoore