### PR TITLE
docs: add Harsh Singh GSoC 2026 blog

### DIFF
--- a/2026/blogs.md
+++ b/2026/blogs.md
@@ -38,6 +38,7 @@ Please fill in your project information using this format:
 - [scikit-bio](https://github.com/scikit-bio/scikit-bio/wiki/GSOC-2026-project-ideas)
 - [SciML](https://sciml.ai/dev/#google_summer_of_code)
 
+    [@singhharsh1708](https://github.com/singhharsh1708), Harsh Singh, [Generic Tableau-Driven Solver Infrastructure for OrdinaryDiffEq.jl](https://singhharsh1708.github.io/gsoc_blog/)
     [@utkuyilmaz1903](https://github.com/utkuyilmaz1903), Utku Yılmaz, [Comprehensive Non-Uniform Grid Support for MethodOfLines.jl](https://utkuyilmaz1903.github.io/kickoff/)
 
 - [Stan](https://github.com/stan-dev/stan/wiki/GSOC-2026-Proposed-Projects)


### PR DESCRIPTION
Added blog link for Harsh Singh under SciML for GSoC 2026.