### PR TITLE
Add Aman Kumar (HoloViz, Lumen + Xarray) to 2026/blogs.md

### DIFF
--- a/2026/blogs.md
+++ b/2026/blogs.md
@@ -33,6 +33,9 @@ Please fill in your project information using this format:
   - [@krcoder123](https://github.com/krcoder123), Kaushik Raja, [Parallelizing r.proj and Raster Processing Modules in GRASS](https://krcoder123.github.io)
 
 - [HoloViz](https://github.com/holoviz/holoviz/wiki/2026-GSoC-Project-List)
+
+  - [@ghostiee-11](https://github.com/ghostiee-11), Aman Kumar, [Lumen + Xarray Integration](https://ghostiee-11.github.io/gsoc26/)
+
 - [Gridap](https://github.com/gridap/GSoC/blob/main/2026/ideas-list.md)
 - [JuMP](https://github.com/jump-dev/GSOC)
 


### PR DESCRIPTION
Adding my contributor entry under HoloViz in `2026/blogs.md`.

I am a 2026 GSoC contributor at HoloViz (under the NumFOCUS umbrella). My project is the Lumen and xarray integration (350 hours), mentored by Andrew Huang and Andy Maloney. My biweekly blog lives at https://ghostiee-11.github.io/gsoc26/.


