### PR TITLE
Tidy 2026/blogs.md: fix 'ls#' typo on title, normalize blank lines and whitespace

### DIFF
--- a/2026/blogs.md
+++ b/2026/blogs.md
@@ -1,4 +1,4 @@
-ls# Blog Pages
+# Blog Pages
 
 This page is for the contributor blogs of NumFOCUS, Google Summer of Code 2026.
 
@@ -13,8 +13,6 @@ Please fill in your project information using this format:
   - [@henrykironde](https://github.com/henrykironde), Henry Senyondo, [Deep Learning Models for Short-Horizon Time Series Forecasting](https://medium.com/@lucifer4073/list/gsoc25-journey-a7cf92345f9a)
 -->
 
-
-
 - [AiiDA](https://github.com/aiidateam/aiida-core/wiki/GSoC-2026-Projects)
 
   - [@Jaweria-B](https://github.com/Jaweria-B), Jaweria Batool, [Teaching Aiida to Speak](https://aiida.net/blog/gsoc-2026-aiida-natural-language/)
@@ -24,6 +22,7 @@ Please fill in your project information using this format:
 - [Data Retriever](https://github.com/weecology/retriever/wiki/GSoC-2026-Project-Ideas)
 
   - [@musaqlain](https://github.com/musaqlain), Muhammad Saqlain, [Recovering historical image data using automated ortho-registration and image-matching](https://musaqlain.dev/blog/gsoc-2026-community-bonding/)
+
 - [gammapy](https://github.com/gammapy/gammapy/wiki/GSoC-2026-Project)
 
   - [@Basmala92](https://github.com/Basmala92), Basmala Hekal, [Serialization Of Map and Model Classes into ASDF](https://medium.com/@Basmala_Hekal/google-summer-of-code-2026-numfocus-gammapy-e341b564c57d)
@@ -43,13 +42,13 @@ Please fill in your project information using this format:
 
 - [matplotlib](https://github.com/matplotlib/matplotlib/wiki/Matplotlib-GSoC-2026-Ideas)
 
-  -  [@Vikash-Kumar-23](https://github.com/Vikash-Kumar-23), Vikash Kumar, [Overlay Layer API](https://Vikash-Kumar-23.github.io)
-      
+  - [@Vikash-Kumar-23](https://github.com/Vikash-Kumar-23), Vikash Kumar, [Overlay Layer API](https://Vikash-Kumar-23.github.io)
+
 - [pvlib](https://github.com/pvlib/pvlib-python/wiki/GSoC-2026-Projects)
 - [PyMC](https://github.com/pymc-devs/pymc/wiki/GSoC-2026-projects)
 
   - [@eclipse1605](https://github.com/eclipse1605), Advay Bhagwat, [Predictively Oriented Posteriors in PyMC](https://eclipse1605.github.io/blogs/)
-    
+
 - [PySAL](https://github.com/pysal/pysal/wiki/Google-Summer-of-Code-2026)
 - [QuTiP](https://github.com/qutip/qutip/wiki//Google-Summer-of-Code-current)
 - [scikit-bio](https://github.com/scikit-bio/scikit-bio/wiki/GSOC-2026-project-ideas)
@@ -57,16 +56,18 @@ Please fill in your project information using this format:
   - [@monkeytim19](https://github.com/monkeytim19), Timothy Wong, [Succinct Data Structure for Efficient Operations on Trees](https://monkeytim19.github.io/)
 
 - [SciML](https://sciml.ai/dev/#google_summer_of_code)
+
   - [@AJ0070](https://github.com/AJ0070), Jash Ambaliya, [Distributed Linear Solvers in LinearSolve.jl](https://dev.to/aj0070/gsoc-2026-kickoff-distributed-linear-solvers-in-linearsolvejl-n82)
   - [@singhharsh1708](https://github.com/singhharsh1708), Harsh Singh, [Generic Tableau-Driven Solver Infrastructure for OrdinaryDiffEq.jl](https://singhharsh1708.github.io/gsoc_blog/)
   - [@utkuyilmaz1903](https://github.com/utkuyilmaz1903), Utku Yılmaz, [Comprehensive Non-Uniform Grid Support for MethodOfLines.jl](https://utkuyilmaz1903.github.io/kickoff/)
 
 - [Stan](https://github.com/stan-dev/stan/wiki/GSOC-2026-Proposed-Projects)
-  
+
   - [@VisruthSK](https://github.com/VisruthSK), Visruth Srimath Kandali, [Parallelizing loo](https://www.visruth.com/blog/20260516-01/)
-  
+
 - [sbi](https://github.com/sbi-dev/sbi/wiki/GSoC%E2%80%902026%E2%80%90Projects)
+
   - [@Jocho-Smith](https://github.com/Jocho-Smith), Johannes Schmidt, [Stateless API for Scalable and Composable Inference in sbi](https://jocho.de/gsocblog.html)
+
 - [toqito](https://github.com/vprusso/toqito/wiki/GSoC-2026-Projects)
 - [pytorch-ignite](https://github.com/pytorch/ignite/wiki/GSoC-2026-project-idea)
-


### PR DESCRIPTION
Small janitorial pass on `2026/blogs.md` to fix a few rendering and formatting issues.

### What is fixed

- **Line 1**: the title read `ls# Blog Pages` (stray `ls` text leaked onto the H1). Restored to `# Blog Pages`.
- Added missing blank lines so each contributor block is visually separated from the next organization: after the `@musaqlain` (Data Retriever) entry, between `- [SciML]` and its three contributors, between `- [Stan]` and its contributor, and between `- [sbi]` and its contributor. This matches the pattern already used by AiiDA, Data Retriever, gammapy, GRASS, HoloViz, JuMP, matplotlib, PyMC and scikit-bio.
- Fixed double space after the bullet in the matplotlib entry (`  -  [@Vikash-Kumar-23]` to `  - [@Vikash-Kumar-23]`).
- Removed trailing whitespace on four lines.
- Collapsed a double blank line after the HTML comment block.