### PR TITLE
Add satwiksps blog entry under sbi

### DIFF
--- a/2026/blogs.md
+++ b/2026/blogs.md
@@ -68,6 +68,7 @@ Please fill in your project information using this format:
 - [sbi](https://github.com/sbi-dev/sbi/wiki/GSoC%E2%80%902026%E2%80%90Projects)
   - [@Jocho-Smith](https://github.com/Jocho-Smith), Johannes Schmidt, [Stateless API for Scalable and Composable Inference in sbi](https://jocho.de/gsocblog.html)
   - [@satwiksps](https://github.com/satwiksps), Satwik Sai Prakash Sahoo, [Neural Network Builder API Refactor](https://dev.to/satwiksps)
+
 - [toqito](https://github.com/vprusso/toqito/wiki/GSoC-2026-Projects)
 - [pytorch-ignite](https://github.com/pytorch/ignite/wiki/GSoC-2026-project-idea)
 

--- a/2026/blogs.md
+++ b/2026/blogs.md
@@ -67,6 +67,7 @@ Please fill in your project information using this format:
   
 - [sbi](https://github.com/sbi-dev/sbi/wiki/GSoC%E2%80%902026%E2%80%90Projects)
   - [@Jocho-Smith](https://github.com/Jocho-Smith), Johannes Schmidt, [Stateless API for Scalable and Composable Inference in sbi](https://jocho.de/gsocblog.html)
+  - [@satwiksps](https://github.com/satwiksps), Satwik Sai Prakash Sahoo, [Neural Network Builder API Refactor](https://dev.to/satwiksps)
 - [toqito](https://github.com/vprusso/toqito/wiki/GSoC-2026-Projects)
 - [pytorch-ignite](https://github.com/pytorch/ignite/wiki/GSoC-2026-project-idea)
 


### PR DESCRIPTION
This PR adds my blog entry under the sbi project section in 2026/blogs.md

GitHub: @satwiksps
Project: [Neural Network Builder API Refactor](https://summerofcode.withgoogle.com/programs/2026/projects/P5QOhl9F)
Blog: https://dev.to/satwiksps