### PR TITLE
DOC: fix broken link in contributing guide

### DIFF
--- a/CONTRIBUTING-contributors.md
+++ b/CONTRIBUTING-contributors.md
@@ -34,7 +34,7 @@ with different backgrounds. At the same time if you have experience using your
 project of choice or one of its dependencies (e.g., language) make sure to let
 us know about that as
 well.
-The [GSoC Guide](https://google.github.io/gsocguides/contributor/am-i-good-enough#)
+The [GSoC Guide](https://google.github.io/gsocguides/student/am-i-good-enough#)
 gives a good overview of this part for GSoC.
 
 ## Our Expectations From Contributors


### PR DESCRIPTION
Greetings,
While going through the repository, I found a dead link in "CONTRIBUTING-contributors.md" under the "Am i experienced enough?" heading this PR updates it to the correct working URL.